### PR TITLE
added Travis CI tests on OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-dist: trusty
+dist: xenial
+jdk:
+  - openjdk8
+  - openjdk11
 notifications:
   slack:
     secure: L7jJ99r+HooZNa/rUiHPcTEkliiBU3datZ46x0yy4zeUOKTXgYE6VoKwjnY4rxU1DX6nXen5rySFeRwVj+Hzr+ljYqlmnxkOn/TIKuL+lgjeBWuB1Y9yWvDEELtiIxhui6/+zdpDS5xS+3YBK1PKGTdbS7iwsuEJDegZoJnUcHuPqgqT3zs1Ds7dpGrSQH5mLZ7bWOG8PYWA5nGWk+6XrGSqeOD15CTfHIdVYFBDxA75fp2VvhI9EiOXbyKEgmce/gKjgW/+p042hHSEaX9nIyHxBCAL6rI/I6Q/oBoPm4Mf9l5jSXYednfD1f5bUaRMqggPKqsNq03tR2JPgf8CX1MUISo1Kpvf51gPGn+2Adixa1ZJ8oLEPAG2qvW2JNyyyOI0mgJxN5XmMlzXsUwLXJVZ7dFjv4YT8MAxWnQC7JUl8gxCoghNdPfn6xHN9ADtwWBFxEHMj6LbQ9ukbV/A9yR06qdRS8m0uSgU5g6nCmVL2bNRf27FRYK+AV6o4eS/Fll6kaTgKR+8rQoEo7wSAOpQLvaEGoMzIH+y2/i+Dmm/YvHhMxqIGw7NNsVPAkh/V7hk82FdoBd0sxD7ZUlx1Mjm+9xcpi0VWX/1rVH9nE9uKxs/cRGKJ1SAFK5P0XmwTh0ag0s+/ATJzTHpVSaoiSrM36LZw0p8mv/10p+zFXo=

--- a/eshop-ws/pom.xml
+++ b/eshop-ws/pom.xml
@@ -69,6 +69,17 @@
             <groupId>com.sun.activation</groupId>
             <artifactId>javax.activation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>jakarta.activation</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -80,27 +91,27 @@
             </plugin>
 
             <!-- generation of sources from XSD schemas -->
-            <!--<plugin>-->
-                <!--<groupId>org.codehaus.mojo</groupId>-->
-                <!--<artifactId>jaxb2-maven-plugin</artifactId>-->
-                <!--<version>2.4</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>xjc</id>-->
-                        <!--<goals>-->
-                            <!--<goal>xjc</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-                <!--<configuration>-->
-                    <!--<sources>-->
-                        <!--<source>${project.basedir}/src/main/resources/prices.xsd</source>-->
-                        <!--<source>${project.basedir}/src/main/resources/products.xsd</source>-->
-                    <!--</sources>-->
-                    <!--<outputDirectory>${project.basedir}/src/main/java</outputDirectory>-->
-                    <!--<clearOutputDir>false</clearOutputDir>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>2.5.0</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sources>
+                        <source>${project.basedir}/src/main/resources/prices.xsd</source>
+                        <source>${project.basedir}/src/main/resources/products.xsd</source>
+                    </sources>
+                    <outputDirectory>${project.basedir}/src/main/java</outputDirectory>
+                    <clearOutputDir>false</clearOutputDir>
+                </configuration>
+            </plugin>
 
 
         </plugins>


### PR DESCRIPTION
changes unit tests run by the Travis Continuous Integration tool to be run on both OpenJDK 8 and 11