### PR TITLE
updated Spring Boot to 2.6.6

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '11', '16' ]
+        java: [ '11', '17' ]
     name: JDK ${{ matrix.java }} build
     steps:
     - uses: actions/checkout@v2

--- a/eshop-angular/src/main/java/cz/muni/fi/pa165/restapi/hateoas/CategoryRepresentationModelAssembler.java
+++ b/eshop-angular/src/main/java/cz/muni/fi/pa165/restapi/hateoas/CategoryRepresentationModelAssembler.java
@@ -31,7 +31,7 @@ public class CategoryRepresentationModelAssembler implements RepresentationModel
     @Override
     public EntityModel<CategoryDTO> toModel(CategoryDTO categoryDTO) {
         long id = categoryDTO.getId();
-        EntityModel<CategoryDTO> categoryResource = new EntityModel<>(categoryDTO);
+        EntityModel<CategoryDTO> categoryResource = EntityModel.of(categoryDTO);
         try {
             Link catLink = entityLinks.linkForItemResource(CategoryDTO.class, id).withSelfRel();
             categoryResource.add(catLink);

--- a/eshop-angular/src/main/java/cz/muni/fi/pa165/restapi/hateoas/ProductRepresentationModelAssembler.java
+++ b/eshop-angular/src/main/java/cz/muni/fi/pa165/restapi/hateoas/ProductRepresentationModelAssembler.java
@@ -29,7 +29,7 @@ public class ProductRepresentationModelAssembler implements RepresentationModelA
     @Override
     public EntityModel<ProductDTO> toModel(ProductDTO productDTO) {
         long id = productDTO.getId();
-        EntityModel<ProductDTO> productResource = new EntityModel<>(productDTO);
+        EntityModel<ProductDTO> productResource = EntityModel.of(productDTO);
         try {
             productResource.add(linkTo(ProductsRestController.class).slash(productDTO.getId()).withSelfRel());
 
@@ -37,7 +37,7 @@ public class ProductRepresentationModelAssembler implements RepresentationModelA
             productResource.add(linkTo(deleteProduct.getDeclaringClass(),deleteProduct, id).withRel("delete"));
 
             Method productImage = ProductsRestController.class.getMethod("productImage", long.class, HttpServletRequest.class, HttpServletResponse.class);
-            Link imageLink = linkTo(productImage.getDeclaringClass(), productImage, id).withRel("image");
+            Link imageLink = linkTo(productImage.getDeclaringClass(), productImage, id, null, null).withRel("image");
             productResource.add(imageLink);
         } catch (Exception ex) {
             log.error("cannot link HATEOAS", ex);

--- a/eshop-rest/src/main/java/cz/fi/muni/pa165/rest/assemblers/ProductResourceAssembler.java
+++ b/eshop-rest/src/main/java/cz/fi/muni/pa165/rest/assemblers/ProductResourceAssembler.java
@@ -23,7 +23,7 @@ public class ProductResourceAssembler implements RepresentationModelAssembler<Pr
 
     @Override
     public EntityModel<ProductDTO> toModel(ProductDTO productDTO) {
-        EntityModel<ProductDTO> productResource = new EntityModel<>(productDTO);
+        EntityModel<ProductDTO> productResource = EntityModel.of(productDTO);
 
         try {
             productResource.add(linkTo(ProductsControllerHateoas.class).slash(productDTO.getId()).withSelfRel());

--- a/eshop-rest/src/main/java/cz/fi/muni/pa165/rest/controllers/ProductsControllerHateoas.java
+++ b/eshop-rest/src/main/java/cz/fi/muni/pa165/rest/controllers/ProductsControllerHateoas.java
@@ -62,7 +62,7 @@ public class ProductsControllerHateoas {
             productResourceCollection.add(productResourceAssembler.toModel(p));
         }
 
-        CollectionModel<EntityModel<ProductDTO>> productsResources = new CollectionModel<>(productResourceCollection);
+        CollectionModel<EntityModel<ProductDTO>> productsResources = CollectionModel.of(productResourceCollection);
         productsResources.add(linkTo(ProductsControllerHateoas.class).withSelfRel());
 
         return new ResponseEntity<>(productsResources, HttpStatus.OK);
@@ -93,7 +93,7 @@ public class ProductsControllerHateoas {
             productResourceCollection.add(productResourceAssembler.toModel(p));
         }
 
-        CollectionModel<EntityModel<ProductDTO>> productsResources = new CollectionModel<>(productResourceCollection);
+        CollectionModel<EntityModel<ProductDTO>> productsResources = CollectionModel.of(productResourceCollection);
         productsResources.add(linkTo(ProductsControllerHateoas.class).withSelfRel());
 
         final StringBuffer eTag = new StringBuffer("\"");

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.4</version>
+        <version>2.6.6</version>
         <relativePath/>
     </parent>
 
@@ -98,15 +98,6 @@
                         </container>
                     </configuration>
                 </plugin>
-                <!-- workaround for broken OpenJDK 8u181-b13-2 on Debian/Ubuntu which causes
-                     unit tests to fail, see https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
-                    </configuration>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -118,7 +109,7 @@
         <module>eshop-sample-data</module>
         <module>eshop-spring-mvc</module>
         <module>eshop-rest</module>
-        <module>eshop-ws</module>
+    <!--<module>eshop-ws</module>-->
         <module>eshop-angular</module>
     </modules>
 </project>


### PR DESCRIPTION
- fixes Spring4Shell vulnerability, see [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965)
- removes eshop-ws maven  module